### PR TITLE
Make href prop optional in SmartLink

### DIFF
--- a/.changeset/popular-cows-peel.md
+++ b/.changeset/popular-cows-peel.md
@@ -1,0 +1,5 @@
+---
+'@undataforum/components': minor
+---
+
+Make href prop optional in SmartLink

--- a/docs/src/stories/components/SmartLink.stories.js
+++ b/docs/src/stories/components/SmartLink.stories.js
@@ -29,4 +29,14 @@ storiesOf('Components/SmartLink', module)
         external link
       </SmartLink>
     </Box>
+  ))
+  .add('disabled link', () => (
+    <Box sx={{ m: 2 }}>
+      <SmartLink
+        sx={{ fontFamily: 'body' }}
+        variant={select('variant', variants, 'primary')}
+      >
+        disabled link
+      </SmartLink>
+    </Box>
   ));

--- a/packages/components/src/smart-link.js
+++ b/packages/components/src/smart-link.js
@@ -43,7 +43,9 @@ export const linkType = shape({
 
 SmartLink.propTypes = {
   children: node.isRequired,
-  href: string.isRequired,
+  // If href is omitted, link is disabled.
+  // This is useful for dynamically disable links in navigations.
+  href: string,
   label: string,
   variant: variantType,
 };


### PR DESCRIPTION
Closes GH-447.