### PR TITLE
Make href optional in NewTabLink

### DIFF
--- a/.changeset/little-crabs-burn.md
+++ b/.changeset/little-crabs-burn.md
@@ -1,0 +1,5 @@
+---
+'@undataforum/components': patch
+---
+
+Make href optional in NewTabLink

--- a/packages/components/src/new-tab-link.js
+++ b/packages/components/src/new-tab-link.js
@@ -14,7 +14,7 @@ const NewTabLink = ({ children, href, className }) => (
 
 NewTabLink.propTypes = {
   children: node.isRequired,
-  href: string.isRequired,
+  href: string,
   className: string,
 };
 


### PR DESCRIPTION
Closes GH-450.